### PR TITLE
Fix saved form not showing on dashboard

### DIFF
--- a/workflow-engine/app/Http/Controllers/FormController.php
+++ b/workflow-engine/app/Http/Controllers/FormController.php
@@ -3,12 +3,109 @@
 namespace App\Http\Controllers;
 
 use App\Models\Form;
+use App\Models\FormField;
+use App\Models\Workflow;
+use Illuminate\Http\Request;
 
 class FormController extends Controller
 {
     public function index()
     {
         return Form::with('workflow', 'fields')->latest()->paginate(20);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'workflow_id' => 'nullable|exists:workflows,id',
+            'fields' => 'required|array|min:1',
+            'fields.*.label' => 'required|string',
+            'fields.*.type' => 'required|string|in:text,number,date,select,radio,checkbox,file,textarea',
+            'fields.*.variable_name' => 'required|string',
+            'fields.*.options' => 'nullable|array',
+            'fields.*.default_value' => 'nullable|string',
+            'fields.*.is_required' => 'boolean',
+        ]);
+
+        $form = Form::create([
+            'workflow_id' => $data['workflow_id'] ?? null,
+            'name' => $data['name'],
+            'description' => $data['description'],
+            'created_by' => $request->user()->id,
+            'updated_by' => $request->user()->id,
+            'is_active' => true,
+        ]);
+
+        // Create form fields
+        foreach ($data['fields'] as $fieldData) {
+            FormField::create([
+                'form_id' => $form->id,
+                'label' => $fieldData['label'],
+                'type' => $fieldData['type'],
+                'variable_name' => $fieldData['variable_name'],
+                'options' => $fieldData['options'] ?? [],
+                'default_value' => $fieldData['default_value'] ?? null,
+                'is_required' => $fieldData['is_required'] ?? false,
+                'validation_rules' => null,
+            ]);
+        }
+
+        return response()->json($form->load('workflow', 'fields'), 201);
+    }
+
+    public function show(Form $form)
+    {
+        return response()->json($form->load('workflow', 'fields'));
+    }
+
+    public function update(Request $request, Form $form)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'workflow_id' => 'nullable|exists:workflows,id',
+            'is_active' => 'boolean',
+            'fields' => 'required|array|min:1',
+            'fields.*.label' => 'required|string',
+            'fields.*.type' => 'required|string|in:text,number,date,select,radio,checkbox,file,textarea',
+            'fields.*.variable_name' => 'required|string',
+            'fields.*.options' => 'nullable|array',
+            'fields.*.default_value' => 'nullable|string',
+            'fields.*.is_required' => 'boolean',
+        ]);
+
+        $form->update([
+            'workflow_id' => $data['workflow_id'] ?? $form->workflow_id,
+            'name' => $data['name'],
+            'description' => $data['description'],
+            'is_active' => $data['is_active'] ?? $form->is_active,
+            'updated_by' => $request->user()->id,
+        ]);
+
+        // Recreate form fields
+        FormField::where('form_id', $form->id)->delete();
+        foreach ($data['fields'] as $fieldData) {
+            FormField::create([
+                'form_id' => $form->id,
+                'label' => $fieldData['label'],
+                'type' => $fieldData['type'],
+                'variable_name' => $fieldData['variable_name'],
+                'options' => $fieldData['options'] ?? [],
+                'default_value' => $fieldData['default_value'] ?? null,
+                'is_required' => $fieldData['is_required'] ?? false,
+                'validation_rules' => null,
+            ]);
+        }
+
+        return response()->json($form->fresh()->load('workflow', 'fields'));
+    }
+
+    public function destroy(Form $form)
+    {
+        $form->delete();
+        return response()->json(['message' => 'Form deleted successfully']);
     }
 }
 

--- a/workflow-engine/app/Http/Controllers/FormController.php
+++ b/workflow-engine/app/Http/Controllers/FormController.php
@@ -3,56 +3,12 @@
 namespace App\Http\Controllers;
 
 use App\Models\Form;
-use App\Models\FormField;
-use App\Models\Workflow;
-use Illuminate\Http\Request;
 
 class FormController extends Controller
 {
     public function index()
     {
         return Form::with('workflow', 'fields')->latest()->paginate(20);
-    }
-
-    public function store(Request $request)
-    {
-        $data = $request->validate([
-            'name' => 'required|string|max:255',
-            'description' => 'nullable|string',
-            'workflow_id' => 'required|exists:workflows,id',
-            'fields' => 'required|array',
-            'fields.*.label' => 'required|string',
-            'fields.*.type' => 'required|string|in:text,number,date,select,radio,checkbox,file,textarea',
-            'fields.*.variable_name' => 'required|string',
-            'fields.*.options' => 'nullable|array',
-            'fields.*.default_value' => 'nullable|string',
-            'fields.*.is_required' => 'boolean',
-        ]);
-
-        $form = Form::create([
-            'workflow_id' => $data['workflow_id'],
-            'name' => $data['name'],
-            'description' => $data['description'],
-            'created_by' => $request->user()->id,
-            'updated_by' => $request->user()->id,
-            'is_active' => true,
-        ]);
-
-        // Create form fields
-        foreach ($data['fields'] as $fieldData) {
-            FormField::create([
-                'form_id' => $form->id,
-                'label' => $fieldData['label'],
-                'type' => $fieldData['type'],
-                'variable_name' => $fieldData['variable_name'],
-                'options' => $fieldData['options'] ?? [],
-                'default_value' => $fieldData['default_value'] ?? null,
-                'is_required' => $fieldData['is_required'] ?? false,
-                'validation_rules' => null,
-            ]);
-        }
-
-        return response()->json($form->load('workflow', 'fields'), 201);
     }
 }
 

--- a/workflow-engine/app/Http/Controllers/FormController.php
+++ b/workflow-engine/app/Http/Controllers/FormController.php
@@ -3,12 +3,56 @@
 namespace App\Http\Controllers;
 
 use App\Models\Form;
+use App\Models\FormField;
+use App\Models\Workflow;
+use Illuminate\Http\Request;
 
 class FormController extends Controller
 {
     public function index()
     {
         return Form::with('workflow', 'fields')->latest()->paginate(20);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'workflow_id' => 'required|exists:workflows,id',
+            'fields' => 'required|array',
+            'fields.*.label' => 'required|string',
+            'fields.*.type' => 'required|string|in:text,number,date,select,radio,checkbox,file,textarea',
+            'fields.*.variable_name' => 'required|string',
+            'fields.*.options' => 'nullable|array',
+            'fields.*.default_value' => 'nullable|string',
+            'fields.*.is_required' => 'boolean',
+        ]);
+
+        $form = Form::create([
+            'workflow_id' => $data['workflow_id'],
+            'name' => $data['name'],
+            'description' => $data['description'],
+            'created_by' => $request->user()->id,
+            'updated_by' => $request->user()->id,
+            'is_active' => true,
+        ]);
+
+        // Create form fields
+        foreach ($data['fields'] as $fieldData) {
+            FormField::create([
+                'form_id' => $form->id,
+                'label' => $fieldData['label'],
+                'type' => $fieldData['type'],
+                'variable_name' => $fieldData['variable_name'],
+                'options' => $fieldData['options'] ?? [],
+                'default_value' => $fieldData['default_value'] ?? null,
+                'is_required' => $fieldData['is_required'] ?? false,
+                'validation_rules' => null,
+            ]);
+        }
+
+        return response()->json($form->load('workflow', 'fields'), 201);
     }
 }
 

--- a/workflow-engine/database/migrations/2025_09_14_150003_make_forms_workflow_id_nullable.php
+++ b/workflow-engine/database/migrations/2025_09_14_150003_make_forms_workflow_id_nullable.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->dropForeign(['workflow_id']);
+            $table->foreignId('workflow_id')->nullable()->change()->constrained()->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->dropForeign(['workflow_id']);
+            $table->foreignId('workflow_id')->nullable(false)->change()->constrained()->onDelete('cascade');
+        });
+    }
+};

--- a/workflow-engine/resources/js/pages/FormsPage.vue
+++ b/workflow-engine/resources/js/pages/FormsPage.vue
@@ -1,11 +1,6 @@
 <template>
     <div class="bg-white p-6 rounded shadow">
-        <div class="flex justify-between items-center mb-4">
-            <h1 class="text-xl font-bold">Forms</h1>
-            <button @click="showCreateForm = true" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
-                Create New Form
-            </button>
-        </div>
+        <h1 class="text-xl font-bold mb-4">Forms</h1>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
                 <h2 class="font-semibold mb-2">Published Forms</h2>
@@ -16,7 +11,7 @@
                     </li>
                 </ul>
                 <div v-if="forms.length === 0" class="text-gray-500 text-sm py-4">
-                    No forms found. Create a form to get started.
+                    No forms found. Create a form template in the <a href="/dashboard/builder/form" class="text-blue-600 hover:underline">Form Builder</a> and link it to a workflow.
                 </div>
             </div>
             <div v-if="selected">
@@ -46,82 +41,6 @@
                 </div>
             </div>
         </div>
-
-        <!-- Create Form Modal -->
-        <div v-if="showCreateForm" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-            <div class="bg-white p-6 rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-                <h2 class="text-xl font-bold mb-4">Create New Form</h2>
-                
-                <form @submit.prevent="createForm" class="space-y-4">
-                    <div>
-                        <label class="block text-sm font-medium mb-1">Form Name</label>
-                        <input v-model="newForm.name" type="text" required class="w-full border rounded p-2" placeholder="Enter form name">
-                    </div>
-                    
-                    <div>
-                        <label class="block text-sm font-medium mb-1">Description</label>
-                        <textarea v-model="newForm.description" class="w-full border rounded p-2" placeholder="Enter form description"></textarea>
-                    </div>
-                    
-                    <div>
-                        <label class="block text-sm font-medium mb-1">Workflow</label>
-                        <select v-model="newForm.workflow_id" required class="w-full border rounded p-2">
-                            <option value="">Select a workflow</option>
-                            <option v-for="workflow in workflows" :key="workflow.id" :value="workflow.id">
-                                {{ workflow.name }}
-                            </option>
-                        </select>
-                    </div>
-                    
-                    <div>
-                        <label class="block text-sm font-medium mb-2">Form Fields</label>
-                        <div class="space-y-3">
-                            <div v-for="(field, index) in newForm.fields" :key="index" class="border rounded p-3">
-                                <div class="flex justify-between items-start mb-2">
-                                    <h4 class="font-medium">Field {{ index + 1 }}</h4>
-                                    <button type="button" @click="removeField(index)" class="text-red-600 text-sm">Remove</button>
-                                </div>
-                                <div class="grid grid-cols-2 gap-2">
-                                    <input v-model="field.label" type="text" placeholder="Field Label" class="border rounded p-2" required>
-                                    <select v-model="field.type" class="border rounded p-2" required>
-                                        <option value="text">Text</option>
-                                        <option value="number">Number</option>
-                                        <option value="date">Date</option>
-                                        <option value="select">Select</option>
-                                        <option value="radio">Radio</option>
-                                        <option value="checkbox">Checkbox</option>
-                                        <option value="file">File</option>
-                                        <option value="textarea">Textarea</option>
-                                    </select>
-                                </div>
-                                <div class="grid grid-cols-2 gap-2 mt-2">
-                                    <input v-model="field.variable_name" type="text" placeholder="Variable Name" class="border rounded p-2" required>
-                                    <input v-model="field.default_value" type="text" placeholder="Default Value" class="border rounded p-2">
-                                </div>
-                                <div class="mt-2">
-                                    <label class="flex items-center">
-                                        <input v-model="field.is_required" type="checkbox" class="mr-2">
-                                        Required field
-                                    </label>
-                                </div>
-                            </div>
-                            <button type="button" @click="addField" class="px-3 py-2 bg-gray-200 rounded hover:bg-gray-300">
-                                Add Field
-                            </button>
-                        </div>
-                    </div>
-                    
-                    <div class="flex justify-end space-x-2">
-                        <button type="button" @click="showCreateForm = false" class="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400">
-                            Cancel
-                        </button>
-                        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
-                            Create Form
-                        </button>
-                    </div>
-                </form>
-            </div>
-        </div>
     </div>
 </template>
 
@@ -131,95 +50,15 @@ import { onMounted, ref } from 'vue';
 
 const forms = ref([]);
 const selected = ref(null);
-const showCreateForm = ref(false);
-const workflows = ref([]);
 
-const newForm = ref({
-    name: '',
-    description: '',
-    workflow_id: '',
-    fields: [
-        {
-            label: '',
-            type: 'text',
-            variable_name: '',
-            default_value: '',
-            is_required: false
-        }
-    ]
-});
-
-onMounted(() => {
-    load();
-    loadWorkflows();
-});
+onMounted(load);
 
 async function load() {
-    try {
-        const res = await axios.get('/forms');
-        forms.value = res.data.data ?? res.data;
-        selected.value = forms.value[0] || null;
-    } catch (error) {
-        console.error('Error loading forms:', error);
-    }
+    const res = await axios.get('/forms');
+    forms.value = res.data.data ?? res.data;
+    selected.value = forms.value[0] || null;
 }
 
-async function loadWorkflows() {
-    try {
-        const res = await axios.get('/workflows');
-        workflows.value = res.data.data ?? res.data;
-    } catch (error) {
-        console.error('Error loading workflows:', error);
-    }
-}
-
-function select(f) { 
-    selected.value = f; 
-}
-
-function addField() {
-    newForm.value.fields.push({
-        label: '',
-        type: 'text',
-        variable_name: '',
-        default_value: '',
-        is_required: false
-    });
-}
-
-function removeField(index) {
-    if (newForm.value.fields.length > 1) {
-        newForm.value.fields.splice(index, 1);
-    }
-}
-
-async function createForm() {
-    try {
-        await axios.post('/forms', newForm.value);
-        showCreateForm.value = false;
-        resetNewForm();
-        await load(); // Reload forms list
-    } catch (error) {
-        console.error('Error creating form:', error);
-        alert('Error creating form: ' + (error.response?.data?.message || error.message));
-    }
-}
-
-function resetNewForm() {
-    newForm.value = {
-        name: '',
-        description: '',
-        workflow_id: '',
-        fields: [
-            {
-                label: '',
-                type: 'text',
-                variable_name: '',
-                default_value: '',
-                is_required: false
-            }
-        ]
-    };
-}
+function select(f) { selected.value = f; }
 </script>
 

--- a/workflow-engine/resources/js/pages/FormsPage.vue
+++ b/workflow-engine/resources/js/pages/FormsPage.vue
@@ -1,18 +1,36 @@
 <template>
     <div class="bg-white p-6 rounded shadow">
-        <h1 class="text-xl font-bold mb-4">Forms</h1>
+        <div class="flex justify-between items-center mb-4">
+            <h1 class="text-xl font-bold">Forms Management</h1>
+            <button @click="openCreateModal" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                Create New Form
+            </button>
+        </div>
+        
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
-                <h2 class="font-semibold mb-2">Published Forms</h2>
-                <ul class="divide-y">
-                    <li v-for="f in forms" :key="f.id" class="py-3 cursor-pointer hover:bg-gray-50 px-2 rounded" @click="select(f)">
-                        <div class="font-medium">{{ f.name }}</div>
-                        <div class="text-xs text-gray-500">Workflow: {{ f.workflow?.name || '—' }}</div>
+                <h2 class="font-semibold mb-2">All Forms</h2>
+                <div v-if="forms.length === 0" class="text-gray-500 text-sm py-4">
+                    No forms found. Create your first form to get started.
+                </div>
+                <ul v-else class="divide-y">
+                    <li v-for="f in forms" :key="f.id" class="py-3 cursor-pointer hover:bg-gray-50 px-2 rounded" @click="select(f)" :class="{ 'bg-blue-50 border-l-4 border-blue-400': selected?.id === f.id }">
+                        <div class="flex justify-between items-start">
+                            <div class="flex-1">
+                                <div class="font-medium">{{ f.name }}</div>
+                                <div class="text-xs text-gray-500">
+                                    Workflow: {{ f.workflow?.name || 'No workflow' }}
+                                    <span v-if="!f.is_active" class="ml-2 text-orange-600">(Inactive)</span>
+                                </div>
+                                <div class="text-xs text-gray-400">{{ f.fields?.length || 0 }} fields</div>
+                            </div>
+                            <div class="flex gap-1 ml-2">
+                                <button @click.stop="editForm(f)" class="text-blue-600 hover:text-blue-800 text-sm px-2 py-1">Edit</button>
+                                <button @click.stop="deleteForm(f)" class="text-red-600 hover:text-red-800 text-sm px-2 py-1">Delete</button>
+                            </div>
+                        </div>
                     </li>
                 </ul>
-                <div v-if="forms.length === 0" class="text-gray-500 text-sm py-4">
-                    No forms found. Create a form template in the <a href="/dashboard/builder/form" class="text-blue-600 hover:underline">Form Builder</a> and link it to a workflow.
-                </div>
             </div>
             <div v-if="selected">
                 <h2 class="font-semibold mb-2">Preview: {{ selected.name }}</h2>
@@ -41,6 +59,90 @@
                 </div>
             </div>
         </div>
+
+        <!-- Form Modal -->
+        <div v-if="showModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div class="bg-white p-6 rounded-lg max-w-4xl w-full max-h-[90vh] overflow-y-auto">
+                <h2 class="text-xl font-bold mb-4">{{ editingForm ? 'Edit Form' : 'Create New Form' }}</h2>
+                
+                <form @submit.prevent="saveForm" class="space-y-4">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label class="block text-sm font-medium mb-1">Form Name</label>
+                            <input v-model="formData.name" type="text" required class="w-full border rounded p-2" placeholder="Enter form name">
+                        </div>
+                        
+                        <div>
+                            <label class="block text-sm font-medium mb-1">Workflow (Optional)</label>
+                            <select v-model="formData.workflow_id" class="w-full border rounded p-2">
+                                <option value="">No workflow</option>
+                                <option v-for="workflow in workflows" :key="workflow.id" :value="workflow.id">
+                                    {{ workflow.name }}
+                                </option>
+                            </select>
+                        </div>
+                    </div>
+                    
+                    <div>
+                        <label class="block text-sm font-medium mb-1">Description</label>
+                        <textarea v-model="formData.description" class="w-full border rounded p-2" placeholder="Enter form description"></textarea>
+                    </div>
+                    
+                    <div class="flex items-center">
+                        <input v-model="formData.is_active" type="checkbox" id="is_active" class="mr-2">
+                        <label for="is_active" class="text-sm font-medium">Active</label>
+                    </div>
+                    
+                    <div>
+                        <label class="block text-sm font-medium mb-2">Form Fields</label>
+                        <div class="space-y-3">
+                            <div v-for="(field, index) in formData.fields" :key="index" class="border rounded p-3">
+                                <div class="flex justify-between items-start mb-2">
+                                    <h4 class="font-medium">Field {{ index + 1 }}</h4>
+                                    <button type="button" @click="removeField(index)" class="text-red-600 text-sm px-2 py-1" :disabled="formData.fields.length === 1">Remove</button>
+                                </div>
+                                <div class="grid grid-cols-2 md:grid-cols-4 gap-2">
+                                    <input v-model="field.label" type="text" placeholder="Field Label" class="border rounded p-2" required>
+                                    <select v-model="field.type" class="border rounded p-2" required>
+                                        <option value="text">Text</option>
+                                        <option value="number">Number</option>
+                                        <option value="date">Date</option>
+                                        <option value="select">Select</option>
+                                        <option value="radio">Radio</option>
+                                        <option value="checkbox">Checkbox</option>
+                                        <option value="file">File</option>
+                                        <option value="textarea">Textarea</option>
+                                    </select>
+                                    <input v-model="field.variable_name" type="text" placeholder="Variable Name" class="border rounded p-2" required>
+                                    <input v-model="field.default_value" type="text" placeholder="Default Value" class="border rounded p-2">
+                                </div>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-2 mt-2">
+                                    <div class="flex items-center">
+                                        <input v-model="field.is_required" type="checkbox" class="mr-2">
+                                        <label class="text-sm">Required field</label>
+                                    </div>
+                                    <div v-if="['select','radio','checkbox'].includes(field.type)">
+                                        <input v-model="field.optionsText" type="text" placeholder="Options (comma-separated)" class="border rounded p-2 w-full">
+                                    </div>
+                                </div>
+                            </div>
+                            <button type="button" @click="addField" class="px-3 py-2 bg-gray-200 rounded hover:bg-gray-300">
+                                Add Field
+                            </button>
+                        </div>
+                    </div>
+                    
+                    <div class="flex justify-end space-x-2">
+                        <button type="button" @click="closeModal" class="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400">
+                            Cancel
+                        </button>
+                        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                            {{ editingForm ? 'Update Form' : 'Create Form' }}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -50,15 +152,172 @@ import { onMounted, ref } from 'vue';
 
 const forms = ref([]);
 const selected = ref(null);
+const showModal = ref(false);
+const editingForm = ref(null);
+const workflows = ref([]);
 
-onMounted(load);
+const formData = ref({
+    name: '',
+    description: '',
+    workflow_id: '',
+    is_active: true,
+    fields: [
+        {
+            label: '',
+            type: 'text',
+            variable_name: '',
+            default_value: '',
+            is_required: false,
+            optionsText: ''
+        }
+    ]
+});
+
+onMounted(() => {
+    load();
+    loadWorkflows();
+});
 
 async function load() {
-    const res = await axios.get('/forms');
-    forms.value = res.data.data ?? res.data;
-    selected.value = forms.value[0] || null;
+    try {
+        const res = await axios.get('/forms');
+        forms.value = res.data.data ?? res.data;
+        if (forms.value.length > 0 && !selected.value) {
+            selected.value = forms.value[0];
+        }
+    } catch (error) {
+        console.error('Error loading forms:', error);
+    }
 }
 
-function select(f) { selected.value = f; }
+async function loadWorkflows() {
+    try {
+        const res = await axios.get('/workflows');
+        workflows.value = res.data.data ?? res.data;
+    } catch (error) {
+        console.error('Error loading workflows:', error);
+    }
+}
+
+function select(f) { 
+    selected.value = f; 
+}
+
+function openCreateModal() {
+    editingForm.value = null;
+    resetFormData();
+    showModal.value = true;
+}
+
+function editForm(form) {
+    editingForm.value = form;
+    formData.value = {
+        name: form.name,
+        description: form.description || '',
+        workflow_id: form.workflow_id || '',
+        is_active: form.is_active,
+        fields: form.fields?.map(field => ({
+            label: field.label,
+            type: field.type,
+            variable_name: field.variable_name,
+            default_value: field.default_value || '',
+            is_required: field.is_required,
+            optionsText: Array.isArray(field.options) ? field.options.join(', ') : ''
+        })) || [{
+            label: '',
+            type: 'text',
+            variable_name: '',
+            default_value: '',
+            is_required: false,
+            optionsText: ''
+        }]
+    };
+    showModal.value = true;
+}
+
+function addField() {
+    formData.value.fields.push({
+        label: '',
+        type: 'text',
+        variable_name: '',
+        default_value: '',
+        is_required: false,
+        optionsText: ''
+    });
+}
+
+function removeField(index) {
+    if (formData.value.fields.length > 1) {
+        formData.value.fields.splice(index, 1);
+    }
+}
+
+async function saveForm() {
+    try {
+        const dataToSend = {
+            ...formData.value,
+            fields: formData.value.fields.map(field => ({
+                label: field.label,
+                type: field.type,
+                variable_name: field.variable_name,
+                default_value: field.default_value,
+                is_required: field.is_required,
+                options: field.optionsText ? field.optionsText.split(',').map(o => o.trim()).filter(Boolean) : []
+            }))
+        };
+
+        if (editingForm.value) {
+            await axios.put(`/forms/${editingForm.value.id}`, dataToSend);
+        } else {
+            await axios.post('/forms', dataToSend);
+        }
+
+        closeModal();
+        await load();
+    } catch (error) {
+        console.error('Error saving form:', error);
+        alert('Error saving form: ' + (error.response?.data?.message || error.message));
+    }
+}
+
+async function deleteForm(form) {
+    if (confirm(`Are you sure you want to delete "${form.name}"?`)) {
+        try {
+            await axios.delete(`/forms/${form.id}`);
+            await load();
+            if (selected.value?.id === form.id) {
+                selected.value = forms.value[0] || null;
+            }
+        } catch (error) {
+            console.error('Error deleting form:', error);
+            alert('Error deleting form: ' + (error.response?.data?.message || error.message));
+        }
+    }
+}
+
+function closeModal() {
+    showModal.value = false;
+    editingForm.value = null;
+    resetFormData();
+}
+
+function resetFormData() {
+    formData.value = {
+        name: '',
+        description: '',
+        workflow_id: '',
+        is_active: true,
+        fields: [
+            {
+                label: '',
+                type: 'text',
+                variable_name: '',
+                default_value: '',
+                is_required: false,
+                optionsText: ''
+            }
+        ]
+    };
+}
 </script>
 

--- a/workflow-engine/resources/js/pages/FormsPage.vue
+++ b/workflow-engine/resources/js/pages/FormsPage.vue
@@ -1,6 +1,11 @@
 <template>
     <div class="bg-white p-6 rounded shadow">
-        <h1 class="text-xl font-bold mb-4">Forms</h1>
+        <div class="flex justify-between items-center mb-4">
+            <h1 class="text-xl font-bold">Forms</h1>
+            <button @click="showCreateForm = true" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                Create New Form
+            </button>
+        </div>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
                 <h2 class="font-semibold mb-2">Published Forms</h2>
@@ -10,6 +15,9 @@
                         <div class="text-xs text-gray-500">Workflow: {{ f.workflow?.name || '—' }}</div>
                     </li>
                 </ul>
+                <div v-if="forms.length === 0" class="text-gray-500 text-sm py-4">
+                    No forms found. Create a form to get started.
+                </div>
             </div>
             <div v-if="selected">
                 <h2 class="font-semibold mb-2">Preview: {{ selected.name }}</h2>
@@ -38,6 +46,82 @@
                 </div>
             </div>
         </div>
+
+        <!-- Create Form Modal -->
+        <div v-if="showCreateForm" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div class="bg-white p-6 rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+                <h2 class="text-xl font-bold mb-4">Create New Form</h2>
+                
+                <form @submit.prevent="createForm" class="space-y-4">
+                    <div>
+                        <label class="block text-sm font-medium mb-1">Form Name</label>
+                        <input v-model="newForm.name" type="text" required class="w-full border rounded p-2" placeholder="Enter form name">
+                    </div>
+                    
+                    <div>
+                        <label class="block text-sm font-medium mb-1">Description</label>
+                        <textarea v-model="newForm.description" class="w-full border rounded p-2" placeholder="Enter form description"></textarea>
+                    </div>
+                    
+                    <div>
+                        <label class="block text-sm font-medium mb-1">Workflow</label>
+                        <select v-model="newForm.workflow_id" required class="w-full border rounded p-2">
+                            <option value="">Select a workflow</option>
+                            <option v-for="workflow in workflows" :key="workflow.id" :value="workflow.id">
+                                {{ workflow.name }}
+                            </option>
+                        </select>
+                    </div>
+                    
+                    <div>
+                        <label class="block text-sm font-medium mb-2">Form Fields</label>
+                        <div class="space-y-3">
+                            <div v-for="(field, index) in newForm.fields" :key="index" class="border rounded p-3">
+                                <div class="flex justify-between items-start mb-2">
+                                    <h4 class="font-medium">Field {{ index + 1 }}</h4>
+                                    <button type="button" @click="removeField(index)" class="text-red-600 text-sm">Remove</button>
+                                </div>
+                                <div class="grid grid-cols-2 gap-2">
+                                    <input v-model="field.label" type="text" placeholder="Field Label" class="border rounded p-2" required>
+                                    <select v-model="field.type" class="border rounded p-2" required>
+                                        <option value="text">Text</option>
+                                        <option value="number">Number</option>
+                                        <option value="date">Date</option>
+                                        <option value="select">Select</option>
+                                        <option value="radio">Radio</option>
+                                        <option value="checkbox">Checkbox</option>
+                                        <option value="file">File</option>
+                                        <option value="textarea">Textarea</option>
+                                    </select>
+                                </div>
+                                <div class="grid grid-cols-2 gap-2 mt-2">
+                                    <input v-model="field.variable_name" type="text" placeholder="Variable Name" class="border rounded p-2" required>
+                                    <input v-model="field.default_value" type="text" placeholder="Default Value" class="border rounded p-2">
+                                </div>
+                                <div class="mt-2">
+                                    <label class="flex items-center">
+                                        <input v-model="field.is_required" type="checkbox" class="mr-2">
+                                        Required field
+                                    </label>
+                                </div>
+                            </div>
+                            <button type="button" @click="addField" class="px-3 py-2 bg-gray-200 rounded hover:bg-gray-300">
+                                Add Field
+                            </button>
+                        </div>
+                    </div>
+                    
+                    <div class="flex justify-end space-x-2">
+                        <button type="button" @click="showCreateForm = false" class="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400">
+                            Cancel
+                        </button>
+                        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                            Create Form
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -47,15 +131,95 @@ import { onMounted, ref } from 'vue';
 
 const forms = ref([]);
 const selected = ref(null);
+const showCreateForm = ref(false);
+const workflows = ref([]);
 
-onMounted(load);
+const newForm = ref({
+    name: '',
+    description: '',
+    workflow_id: '',
+    fields: [
+        {
+            label: '',
+            type: 'text',
+            variable_name: '',
+            default_value: '',
+            is_required: false
+        }
+    ]
+});
+
+onMounted(() => {
+    load();
+    loadWorkflows();
+});
 
 async function load() {
-    const res = await axios.get('/forms');
-    forms.value = res.data.data ?? res.data;
-    selected.value = forms.value[0] || null;
+    try {
+        const res = await axios.get('/forms');
+        forms.value = res.data.data ?? res.data;
+        selected.value = forms.value[0] || null;
+    } catch (error) {
+        console.error('Error loading forms:', error);
+    }
 }
 
-function select(f) { selected.value = f; }
+async function loadWorkflows() {
+    try {
+        const res = await axios.get('/workflows');
+        workflows.value = res.data.data ?? res.data;
+    } catch (error) {
+        console.error('Error loading workflows:', error);
+    }
+}
+
+function select(f) { 
+    selected.value = f; 
+}
+
+function addField() {
+    newForm.value.fields.push({
+        label: '',
+        type: 'text',
+        variable_name: '',
+        default_value: '',
+        is_required: false
+    });
+}
+
+function removeField(index) {
+    if (newForm.value.fields.length > 1) {
+        newForm.value.fields.splice(index, 1);
+    }
+}
+
+async function createForm() {
+    try {
+        await axios.post('/forms', newForm.value);
+        showCreateForm.value = false;
+        resetNewForm();
+        await load(); // Reload forms list
+    } catch (error) {
+        console.error('Error creating form:', error);
+        alert('Error creating form: ' + (error.response?.data?.message || error.message));
+    }
+}
+
+function resetNewForm() {
+    newForm.value = {
+        name: '',
+        description: '',
+        workflow_id: '',
+        fields: [
+            {
+                label: '',
+                type: 'text',
+                variable_name: '',
+                default_value: '',
+                is_required: false
+            }
+        ]
+    };
+}
 </script>
 

--- a/workflow-engine/routes/web.php
+++ b/workflow-engine/routes/web.php
@@ -40,6 +40,7 @@ Route::middleware(['auth'])->group(function () {
 
     // Forms list
     Route::get('/forms', [FormController::class, 'index']);
+    Route::post('/forms', [FormController::class, 'store']);
 
     // Directory
     Route::get('/directory/users', [UserDirectoryController::class, 'users']);

--- a/workflow-engine/routes/web.php
+++ b/workflow-engine/routes/web.php
@@ -38,8 +38,12 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/builder/workflows/{workflow}/form-template', [WorkflowController::class, 'getFormTemplate']);
     Route::get('/workflows/{workflow}/form', [WorkflowController::class, 'getForm']);
 
-    // Forms list
+    // Forms CRUD
     Route::get('/forms', [FormController::class, 'index']);
+    Route::post('/forms', [FormController::class, 'store']);
+    Route::get('/forms/{form}', [FormController::class, 'show']);
+    Route::put('/forms/{form}', [FormController::class, 'update']);
+    Route::delete('/forms/{form}', [FormController::class, 'destroy']);
 
     // Directory
     Route::get('/directory/users', [UserDirectoryController::class, 'users']);

--- a/workflow-engine/routes/web.php
+++ b/workflow-engine/routes/web.php
@@ -40,7 +40,6 @@ Route::middleware(['auth'])->group(function () {
 
     // Forms list
     Route::get('/forms', [FormController::class, 'index']);
-    Route::post('/forms', [FormController::class, 'store']);
 
     // Directory
     Route::get('/directory/users', [UserDirectoryController::class, 'users']);


### PR DESCRIPTION
Add direct form creation functionality to the dashboard to allow users to create and view forms not linked via workflow templates.

Previously, forms could only be created implicitly when a form template was linked to a workflow. This meant there was no direct way to create or manage standalone forms, leading to forms not appearing in the dashboard unless they were part of a workflow template. This PR introduces a dedicated route and UI for direct form creation, ensuring all forms can be managed and viewed from the dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8e2f71b-2769-405f-924f-bad318818772">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8e2f71b-2769-405f-924f-bad318818772">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

